### PR TITLE
arcv: CRC32 for RV32 using clmulr

### DIFF
--- a/gcc/config/riscv/bitmanip.md
+++ b/gcc/config/riscv/bitmanip.md
@@ -1216,7 +1216,7 @@
   "clmulr\t%0,%1,%2"
   [(set_attr "type" "clmul")])
 
-;; Reversed CRC 8, 16, 32 for TARGET_64
+;; Reversed CRC 8, 16, 32
 (define_expand "crc_rev<ANYI1:mode><ANYI:mode>4"
 	;; return value (calculated CRC)
   [(set (match_operand:ANYI 0 "register_operand")
@@ -1235,8 +1235,11 @@
      (E.g.  CRC64's quotient may need 65 bits,
      we can't keep it in 64 bit variable.)
      then use clmul instruction to implement the CRC,
-     otherwise (TARGET_ZBKB) generate table based using brev.  */
-  if ((TARGET_ZBKC || TARGET_ZBC || TARGET_ZVBC) && <ANYI:MODE>mode < word_mode)
+     otherwise (TARGET_ZBKB) generate table based using brev.
+     We can also use clmulr for CRC-32 on RV32, requiring ZBC.  */
+  if (((TARGET_ZBKC || TARGET_ZBC || TARGET_ZVBC)
+	&& <ANYI:MODE>mode < word_mode)
+      || (!TARGET_64BIT && TARGET_ZBC && <ANYI:MODE>mode == word_mode))
     expand_reversed_crc_using_clmul (<ANYI:MODE>mode, <ANYI1:MODE>mode,
 				     operands);
   else if (TARGET_ZBKB)

--- a/gcc/config/riscv/riscv.cc
+++ b/gcc/config/riscv/riscv.cc
@@ -16084,11 +16084,22 @@ expand_reversed_crc_using_clmul (scalar_mode crc_mode, scalar_mode data_mode,
   unsigned HOST_WIDE_INT
   ref_polynomial = reflect_hwi (UINTVAL (polynomial),
 				crc_size);
-  rtx t1 = gen_reg_rtx (word_mode);
-  riscv_emit_move (t1, gen_int_mode (ref_polynomial << 1, word_mode));
 
-  rtx crc = gen_rtx_ZERO_EXTEND (word_mode, operands[1]);
-  rtx data = gen_rtx_ZERO_EXTEND (word_mode, operands[2]);
+  bool use_clmulr = crc_size == BITS_PER_WORD;
+  gcc_assert (TARGET_ZBC || !use_clmulr);
+
+  rtx t1 = gen_reg_rtx (word_mode);
+  if (use_clmulr)
+    riscv_emit_move (t1, gen_int_mode (ref_polynomial, word_mode));
+  else
+    riscv_emit_move (t1, gen_int_mode (ref_polynomial << 1, word_mode));
+
+  rtx crc = operands[1];
+  if (crc_size != BITS_PER_WORD)
+    crc = gen_rtx_ZERO_EXTEND (word_mode, crc);
+  rtx data = operands[2];
+  if (data_size != BITS_PER_WORD)
+    data = gen_rtx_ZERO_EXTEND (word_mode, data);
   rtx a0 = gen_reg_rtx (word_mode);
   riscv_expand_op (XOR, word_mode, a0, crc, data);
 
@@ -16102,10 +16113,18 @@ expand_reversed_crc_using_clmul (scalar_mode crc_mode, scalar_mode data_mode,
       rtx num_shift = gen_int_mode (BITS_PER_WORD - data_size, word_mode);
       riscv_expand_op (ASHIFT, word_mode, a0, a0, num_shift);
 
-      if (TARGET_64BIT)
-	emit_insn (gen_riscv_clmulh_di (a0, a0, t1));
+      if (use_clmulr)
+	{
+	  gcc_assert (!TARGET_64BIT);
+	  emit_insn (gen_riscv_clmulr_si (a0, a0, t1));
+	}
       else
-	emit_insn (gen_riscv_clmulh_si (a0, a0, t1));
+	{
+	  if (TARGET_64BIT)
+	    emit_insn (gen_riscv_clmulh_di (a0, a0, t1));
+	  else
+	    emit_insn (gen_riscv_clmulh_si (a0, a0, t1));
+	}
     }
   else
     {

--- a/gcc/testsuite/gcc.target/riscv/crc-builtin-zbc32.c
+++ b/gcc/testsuite/gcc.target/riscv/crc-builtin-zbc32.c
@@ -19,7 +19,7 @@ int16_t crc16_data16 ()
 }
 
 int32_t rev_crc32_data8 ()
-]{
+{
   return __builtin_rev_crc32_data8 (0x12345678, 'a', 0x04C11DB7);
 }
 

--- a/gcc/testsuite/gcc.target/riscv/crc-builtin-zbc32.c
+++ b/gcc/testsuite/gcc.target/riscv/crc-builtin-zbc32.c
@@ -18,4 +18,20 @@ int16_t crc16_data16 ()
   return __builtin_crc16_data16 (0x1234, 0x3214, 0x1021);
 }
 
-/* { dg-final { scan-assembler-times "clmul\t" 6 } } */
+int32_t rev_crc32_data8 ()
+]{
+  return __builtin_rev_crc32_data8 (0x12345678, 'a', 0x04C11DB7);
+}
+
+int32_t rev_crc32_data16 ()
+{
+  return __builtin_rev_crc32_data16 (0x12345678, 0x3214, 0x04C11DB7);
+}
+
+int32_t rev_crc32_data32 ()
+{
+  return __builtin_rev_crc32_data32 (0x12345678, 0x123546ff, 0x04C11DB7);
+}
+
+/* { dg-final { scan-assembler-times "clmul\t" 9 } } */
+/* { dg-final { scan-assembler-times "clmulr" 3 } } */


### PR DESCRIPTION
As shown in the code snippet in the RISC-V bitmanip spec v0.93 in section 2.8. It is not present in the ratified spec, but the clmulr definition has not changed between them.

This significantly improves performance for rv32 processors that have the zbc extension.

__builtin_rev_crc32_data32 (crc, data, poly) on rv32_zbc now generates:
	li	a4,-150925312
	xor	a0,a0,a1
	addi	a4,a4,1601
	li	a5,-306675712
	clmul	a0,a0,a4
	addi	a5,a5,800
	clmulr	a0,a0,a5

which is more compact and faster than the previous approach which generates more than 300 lines of assembly and table data.