### PR TITLE
arc: make tests big-endian aware

### DIFF
--- a/gcc/testsuite/gcc.target/arc/adddi3-1.c
+++ b/gcc/testsuite/gcc.target/arc/adddi3-1.c
@@ -6,5 +6,7 @@ long long foo(long long x, long long y)
   return x + y;
 }
 
-/* { dg-final { scan-assembler "add.f\\s+r0,r0,r2" } } */
-/* { dg-final { scan-assembler "adc\\s+r1,r1,r3" } } */
+/* { dg-final { scan-assembler "add.f\\s+r0,r0,r2"  { target arc-*-* } } } */
+/* { dg-final { scan-assembler "adc\\s+r1,r1,r3" { target arc-*-* } } } */
+/* { dg-final { scan-assembler "add.f\\s+r1,r1,r3"  { target arceb-*-* } } } */
+/* { dg-final { scan-assembler "adc\\s+r0,r0,r2" { target arceb-*-* } } } */

--- a/gcc/testsuite/gcc.target/arc/ashldi3-1.c
+++ b/gcc/testsuite/gcc.target/arc/ashldi3-1.c
@@ -6,5 +6,7 @@ long long foo(long long x)
   return x << 1;
 }
 
-/* { dg-final { scan-assembler "add.f\\s+r0,r0,r0" } } */
-/* { dg-final { scan-assembler "adc\\s+r1,r1,r1" } } */
+/* { dg-final { scan-assembler "add.f\\s+r0,r0,r0" { target arc-*-* } } } */
+/* { dg-final { scan-assembler "adc\\s+r1,r1,r1" { target arc-*-* } } } */
+/* { dg-final { scan-assembler "add.f\\s+r1,r1,r1" { target arceb-*-* } } } */
+/* { dg-final { scan-assembler "adc\\s+r0,r0,r0" { target arceb-*-* } } } */

--- a/gcc/testsuite/gcc.target/arc/ashrdi3-1.c
+++ b/gcc/testsuite/gcc.target/arc/ashrdi3-1.c
@@ -6,5 +6,7 @@ long long foo(long long x)
   return x >> 1;
 }
 
-/* { dg-final { scan-assembler "asr.f\\s+r1,r1" } } */
-/* { dg-final { scan-assembler "rrc\\s+r0,r0" } } */
+/* { dg-final { scan-assembler "asr.f\\s+r1,r1"  { target arc-*-* } } } */
+/* { dg-final { scan-assembler "rrc\\s+r0,r0"  { target arc-*-* } } } */
+/* { dg-final { scan-assembler "asr.f\\s+r0,r0"  { target arceb-*-* } } } */
+/* { dg-final { scan-assembler "rrc\\s+r1,r1"  { target arceb-*-* } } } */

--- a/gcc/testsuite/gcc.target/arc/lshrdi3-1.c
+++ b/gcc/testsuite/gcc.target/arc/lshrdi3-1.c
@@ -6,5 +6,7 @@ unsigned long long foo(unsigned long long x)
   return x >> 1;
 }
 
-/* { dg-final { scan-assembler "lsr.f\\s+r1,r1" } } */
-/* { dg-final { scan-assembler "rrc\\s+r0,r0" } } */
+/* { dg-final { scan-assembler "lsr.f\\s+r1,r1" { target arc-*-* } } } */
+/* { dg-final { scan-assembler "rrc\\s+r0,r0" { target arc-*-* } } } */
+/* { dg-final { scan-assembler "lsr.f\\s+r0,r0" { target arceb-*-* } } } */
+/* { dg-final { scan-assembler "rrc\\s+r1,r1" { target arceb-*-* } } } */

--- a/gcc/testsuite/gcc.target/arc/rotldi3-1.c
+++ b/gcc/testsuite/gcc.target/arc/rotldi3-1.c
@@ -6,6 +6,9 @@ unsigned long long foo(unsigned long long x)
   return (x << 1) | (x >> 63);
 }
 
-/* { dg-final { scan-assembler "add.f\\s+r0,r0,r0" } } */
-/* { dg-final { scan-assembler "adc.f\\s+r1,r1,r1" } } */
-/* { dg-final { scan-assembler "add.cs\\s+r0,r0,1" } } */
+/* { dg-final { scan-assembler "add.f\\s+r0,r0,r0" { target arc-*-* } } } */
+/* { dg-final { scan-assembler "adc.f\\s+r1,r1,r1" { target arc-*-* } } } */
+/* { dg-final { scan-assembler "add.cs\\s+r0,r0,1" { target arc-*-* } } } */
+/* { dg-final { scan-assembler "add.f\\s+r1,r1,r1" { target arceb-*-* } } } */
+/* { dg-final { scan-assembler "adc.f\\s+r0,r0,r0" { target arceb-*-* } } } */
+/* { dg-final { scan-assembler "add.cs\\s+r1,r1,1" { target arceb-*-* } } } */

--- a/gcc/testsuite/gcc.target/arc/rotrdi3-1.c
+++ b/gcc/testsuite/gcc.target/arc/rotrdi3-1.c
@@ -6,6 +6,9 @@ unsigned long long foo(unsigned long long x)
   return (x >> 1) | (x << 63);
 }
 
-/* { dg-final { scan-assembler "asr.f\\s+0,r0" } } */
-/* { dg-final { scan-assembler "rrc.f\\s+r1,r1" } } */
-/* { dg-final { scan-assembler "rrc\\s+r0,r0" } } */
+/* { dg-final { scan-assembler "asr.f\\s+0,r0" { target arc-*-* } } } */
+/* { dg-final { scan-assembler "rrc.f\\s+r1,r1" { target arc-*-* } } } */
+/* { dg-final { scan-assembler "rrc\\s+r0,r0" { target arc-*-* } } } */
+/* { dg-final { scan-assembler "asr.f\\s+0,r1" { target arceb-*-* } } } */
+/* { dg-final { scan-assembler "rrc.f\\s+r0,r0" { target arceb-*-* } } } */
+/* { dg-final { scan-assembler "rrc\\s+r1,r1" { target arceb-*-* } } } */


### PR DESCRIPTION
These were also already failing under gcc15, Big endian calling convention flips the `long long` arguments in the registers.