### PR TITLE
arc: Fix dmpywh/qmpyh reduction destinations

### DIFF
--- a/gcc/config/arc/simdext.md
+++ b/gcc/config/arc/simdext.md
@@ -2042,9 +2042,20 @@
   [(set_attr "length" "8")
    (set_attr "type" "multi")])
 
-(define_insn "reduc_plus_scal_v4hi"
-  [(set (match_operand:HI 0 "even_register_operand" "=r")
-	(unspec:HI [(match_operand:V4HI 1 "even_register_operand" "r")]
+(define_expand "reduc_plus_scal_v4hi"
+  [(match_operand:HI 0 "register_operand")
+   (match_operand:V4HI 1 "even_register_operand")]
+  "TARGET_PLUS_QMACW"
+  {
+    rtx tmp = gen_reg_rtx (DImode);
+    emit_insn (gen_qmpyh_1 (tmp, operands[1]));
+    emit_move_insn (operands[0], gen_lowpart (HImode, tmp));
+    DONE;
+  })
+
+(define_insn "qmpyh_1"
+  [(set (match_operand:DI 0 "even_register_operand" "=r")
+	(unspec:DI [(match_operand:V4HI 1 "even_register_operand" "r")]
 		   UNSPEC_ARC_QMPYH))
    (clobber (reg:DI ARCV2_ACC))]
   "TARGET_PLUS_QMACW"
@@ -2052,12 +2063,23 @@
   [(set_attr "length" "4")
    (set_attr "type" "multi")])
 
-(define_insn "reduc_plus_scal_v2si"
-  [(set (match_operand:SI 0 "even_register_operand" "=r")
-	(unspec:SI [(match_operand:V2SI 1 "even_register_operand" "r")]
+(define_expand "reduc_plus_scal_v2si"
+  [(match_operand:SI 0 "register_operand")
+   (match_operand:V2SI 1 "even_register_operand")]
+  "TARGET_PLUS_QMACW"
+  {
+    rtx tmp = gen_reg_rtx (DImode);
+    emit_insn (gen_dmpywh_1 (tmp, operands[1]));
+    emit_move_insn (operands[0], gen_lowpart (SImode, tmp));
+    DONE;
+  })
+
+(define_insn "dmpywh_1"
+  [(set (match_operand:DI 0 "even_register_operand" "=r")
+	(unspec:DI [(match_operand:V2SI 1 "even_register_operand" "r")]
 		   UNSPEC_ARC_DMPYWH))
    (clobber (reg:DI ARCV2_ACC))]
-  "TARGET_PLUS_DMPY"
+  "TARGET_PLUS_QMACW"
   "dmpywh\\t%0,%1,1"
   [(set_attr "length" "4")
    (set_attr "type" "multi")])

--- a/gcc/testsuite/gcc.target/arc/reduc-plus-scal-1.c
+++ b/gcc/testsuite/gcc.target/arc/reduc-plus-scal-1.c
@@ -1,0 +1,61 @@
+/* { dg-do run } */
+/* { dg-skip-if "" { *-*-* } { "-mcpu=*" } { "-mcpu=hs38_linux" } } */
+/* { dg-options "-O3 -mcpu=hs38_linux -save-temps -fdump-rtl-expand" } */
+
+typedef int v2si __attribute__ ((vector_size (8)));
+
+int __attribute__ ((noinline, noclone))
+sum_v2si (v2si x)
+{
+  return x[0] + x[1];
+}
+
+short __attribute__ ((noinline, noclone))
+sum_hi (short *p, int n)
+{
+  short s = 0;
+  for (int i = 0; i < n; i++)
+    s += p[i];
+  return s;
+}
+
+unsigned int m;
+#define N 128
+unsigned int a[N];
+
+unsigned int __attribute__ ((noipa))
+df_count_refs (_Bool include_defs)
+{
+  int size = 0;
+  for (unsigned int regno = 0; regno < m; regno++)
+    if (include_defs)
+      size += a[regno];
+  return size;
+}
+
+int
+main (void)
+{
+  v2si v = { 40, 2 };
+  short h[8] = { 1, 2, 3, 4, 5, 6, 7, 8 };
+
+  if (sum_v2si (v) != 42)
+    __builtin_abort ();
+  if (sum_hi (h, 8) != 36)
+    __builtin_abort ();
+
+  for (unsigned i = 0; i < N; i++)
+    a[i] = i;
+  m = 17;
+  if (df_count_refs (1) != 136)
+    __builtin_abort ();
+
+  return 0;
+}
+
+/* { dg-final { scan-rtl-dump "unspec:DI \\\[\\n\[^\\n\]*\\n\[^\\n\]*UNSPEC_ARC_DMPYWH" "expand" } } */
+/* { dg-final { scan-rtl-dump "unspec:DI \\\[\\n\[^\\n\]*\\n\[^\\n\]*UNSPEC_ARC_QMPYH" "expand" } } */
+
+/* register pair must use an even destination.  */
+/* { dg-final { scan-assembler-not "dmpywh\\s+r\[0-9\]*\[13579\]," } } */
+/* { dg-final { scan-assembler-not "qmpyh\\s+r\[0-9\]*\[13579\]," } } */


### PR DESCRIPTION
reduc_plus_scal_v2si and reduc_plus_scal_v4hi expanded to dmpywh/qmpyh with an SImode/HImode destination and constraint "r".  Those instructions write a 64-bit result to an even/odd register pair (and the accumulator).

LRA could therefore assign an odd hard register, which raises an instruction error on HS, or silently clobber dest+1 when the destination happened to be even.  gcc.dg/pr92301.c fails this way at -O3 on hs38.

This was exposed by 309dbcea2ca, which replaced power-of-two shifts on the vector factor with multiply/divide when computing vector loop niters.  That changes the peel/niters compare enough that register allocation more readily picked an odd dmpywh destination for this test.

Expand through a DImode temporary so the destination is a real even/odd pair, then take the lowpart.