### PR TITLE
arc: Correct ctz(0) and clz(0) for ARCompact [PR target/127117]

### DIFF
--- a/gcc/config/arc/arc.md
+++ b/gcc/config/arc/arc.md
@@ -4768,7 +4768,7 @@ archs4x, archs4xd"
   emit_insn
     (gen_rtx_COND_EXEC
       (VOIDmode,
-       gen_rtx_GE (VOIDmode, gen_rtx_REG (CC_ZNmode, CC_REG), const0_rtx),
+       gen_rtx_GT (VOIDmode, gen_rtx_REG (CC_ZNmode, CC_REG), const0_rtx),
        gen_rtx_SET (operands[0], plus_constant (SImode, operands[0], 1))));
   DONE;
 }
@@ -4813,7 +4813,7 @@ archs4x, archs4xd"
     (gen_rtx_COND_EXEC
       (VOIDmode,
        gen_rtx_LT (VOIDmode, gen_rtx_REG (CC_ZNmode, CC_REG), const0_rtx),
-       gen_rtx_SET (operands[0], GEN_INT (32))));
+       gen_rtx_SET (operands[0], GEN_INT (31))));
   emit_insn
     (gen_rtx_COND_EXEC
       (VOIDmode,

--- a/gcc/testsuite/gcc.target/arc/pr127117.c
+++ b/gcc/testsuite/gcc.target/arc/pr127117.c
@@ -1,0 +1,34 @@
+/* { dg-do run } */
+/* { dg-options "-O2 -mnorm" } */
+
+unsigned __attribute__ ((noipa))
+clz (unsigned x)
+{
+  return __builtin_clz (x);
+}
+
+unsigned __attribute__ ((noipa))
+ctz (unsigned x)
+{
+  return __builtin_ctz (x);
+}
+
+int
+main (void)
+{
+  unsigned msb, lsb;
+
+  if (clz (0) != 31 || ctz (0) != 31)
+    __builtin_abort ();
+
+  for (msb = 0; msb < 32; msb++)
+    for (lsb = 0; lsb <= msb; lsb++)
+      {
+	unsigned v = (1u << msb) | (1u << lsb);
+
+	if (clz (v) != 31 - msb || ctz (v) != lsb)
+	  __builtin_abort ();
+      }
+
+  return 0;
+}


### PR DESCRIPTION
CLZ_DEFINED_VALUE_AT_ZERO and CTZ_DEFINED_VALUE_AT_ZERO advertises clz(0) == 31 && ctz(0) == 31. This is true for ARCv2 but not for ARCompact. The latter previously produced 32.

Updated the non-V2 fallback code to produce the same result for zero inputs as this change does not come at any cost.

	PR target/127117

gcc/ChangeLog:

	* config/arc/arc.md (*arc_clzsi2): Produce 31 rather than 32 for a zero operand. (arc_ctzsi2): Idem.

gcc/testsuite/ChangeLog:

	* gcc.target/arc/pr127117.c: New test.