### PR TITLE
arc: Fix incorrect vec_duplicatev4hi [pr63594-2.c]

### DIFF
--- a/gcc/config/arc/simdext.md
+++ b/gcc/config/arc/simdext.md
@@ -2095,9 +2095,12 @@
    emit_insn (gen_rtx_SET (high_dest,
 			   gen_rtx_ASHIFT (SImode, tmp, GEN_INT (16))));
    emit_insn (gen_rtx_SET (low_dest,
-			   gen_rtx_IOR (SImode, high_dest, tmp)));
+			   gen_rtx_LSHIFTRT (SImode, high_dest,
+					     GEN_INT (16))));
+   emit_insn (gen_rtx_SET (low_dest,
+			   gen_rtx_IOR (SImode, low_dest, high_dest)));
    emit_move_insn (high_dest, low_dest);
    DONE;
   }
-  [(set_attr "length" "12")
+  [(set_attr "length" "16")
    (set_attr "type" "multi")])

--- a/gcc/testsuite/gcc.target/arc/vec-duplicate-v4hi.c
+++ b/gcc/testsuite/gcc.target/arc/vec-duplicate-v4hi.c
@@ -1,0 +1,35 @@
+/* { dg-do run } */
+/* { dg-options "-O2" } */
+
+typedef short v4hi __attribute__((vector_size (8)));
+
+__attribute__((noipa)) v4hi
+foo (short c)
+{
+  v4hi v = { c, c, c, c };
+  return v;
+}
+
+__attribute__((noipa)) v4hi
+bar (short unused, short c)
+{
+  v4hi v = { c, c, c, c };
+  return v;
+}
+
+static void
+check (v4hi v, short c)
+{
+  if (v[0] != c || v[1] != c || v[2] != c || v[3] != c)
+    __builtin_abort ();
+}
+
+int
+main (void)
+{
+  short val = -42;
+  check (foo (val), val);
+  check (bar (0, val), val);
+
+  return 0;
+}


### PR DESCRIPTION
v4hi sometimes made incorrect results due to the value in the input register that is not part of the actual input half integer. The assembly generated for the test looked as follows, with simulator register stores:

foo: # arg -42 in r0 = 0xFFFFFFD6 (only low 16 bits are the short)
	asl	r1,r0,16 # r1 <= 0xFFD60000
	or_s	r0,r0,r1 # r0 <= 0xFFFFFFD6
	j_s.d	[blink]
	mov_s	r1,r0 # r1 <= 0xFFFFFFD6
    # resulting vector is {-1, -42, -1, -42}

bar: # arg -42 in r1 = 0xFFFFFFD6 (only low 16 bits are the short)
	asl_s	r1,r1,16 # r1 <= 0xFFD60000
	or	r0,r1,r1 # r0 <= 0xFFD60000
	j_s.d	[blink]
	mov_s	r1,r0 # r1 <= 0xFFD60000
    # resulting vector is {-42, 0, -42, 0}

Adding a logical shift right after the shift left, removes the unwanted bits:

foo: # arg -42 in r0 = 0xFFFFFFD6 (only low 16 bits are the short)
	asl	r1,r0,16 # r1 <= 0xFFD60000
	lsr	r0,r1,16 # r0 <= 0x0000FFD6
	or_s	r0,r0,r1 # r0 <= 0xFFD6FFD6
	j_s.d	[blink]
	mov_s	r1,r0 # r1 <= 0xFFD6FFD6
	# resulting vector is {-42, -42, -42, -42}

bar: # arg -42 in r1 = 0xFFFFFFD6 (only low 16 bits are the short)
	asl_s	r1,r1,16 # r1 <= 0xFFD60000
	lsr	r0,r1,16 # r0 <= 0x0000FFD6
	or	r0,r1,r1 # r0 <= 0xFFD6FFD6
	j_s.d	[blink]
	mov_s	r1,r0 # r1 <= 0xFFD6FFD6
	# resulting vector is {-42, -42, -42, -42}