### PR TITLE
arc: Clobber CC for (do)loop_end

### DIFF
--- a/gcc/config/arc/arc.md
+++ b/gcc/config/arc/arc.md
@@ -4840,7 +4840,8 @@ archs4x, archs4xd"
 
 (define_insn "flag"
   [(unspec_volatile [(match_operand:SI 0 "nonmemory_operand" "rL,I,Cal")]
-		   VUNSPEC_ARC_FLAG)]
+		   VUNSPEC_ARC_FLAG)
+   (clobber (reg:CC CC_REG))]
   ""
   "@
     flag%?\\t%0
@@ -5313,7 +5314,8 @@ archs4x, archs4xd"
 		    (pc)))
 	      (set (match_dup 0) (plus:SI (match_dup 0) (const_int -1)))
 	      (unspec:SI [(const_int 0)] UNSPEC_ARC_LP)
-	      (clobber (match_dup 2))])]
+	      (clobber (match_dup 2))
+	      (clobber (reg:CC CC_REG))])]
   ""
 {
  if (GET_MODE (operands[0]) != SImode)
@@ -5343,7 +5345,8 @@ archs4x, archs4xd"
 		      (pc)))
    (set (match_dup 0) (plus:SI (match_dup 0) (const_int -1)))
    (unspec:SI [(const_int 0)] UNSPEC_ARC_LP)
-   (clobber (match_scratch:SI 2 "=X,&r"))]
+   (clobber (match_scratch:SI 2 "=X,&r"))
+   (clobber (reg:CC CC_REG))]
   ""
   "@
    ; ZOL_END, begins @%l1
@@ -5391,7 +5394,8 @@ archs4x, archs4xd"
    (set (match_dup 0)
 	(plus:SI (match_dup 0)
 		 (const_int -1)))
-   (clobber (match_scratch:SI 2 "=X,r"))]
+   (clobber (match_scratch:SI 2 "=X,r"))
+   (clobber (reg:CC CC_REG))]
   "TARGET_DBNZ"
   "@
    dbnz%*\\t%0,%l1
@@ -5814,7 +5818,8 @@ archs4x, archs4xd"
 
 (define_insn "kflag"
   [(unspec_volatile [(match_operand:SI 0 "nonmemory_operand" "rL,I,Cal")]
-		   VUNSPEC_ARC_KFLAG)]
+		   VUNSPEC_ARC_KFLAG)
+   (clobber (reg:CC CC_REG))]
   "TARGET_V2"
   "@
     kflag%?\\t%0

--- a/gcc/testsuite/gcc.target/arc/pr127191-1.c
+++ b/gcc/testsuite/gcc.target/arc/pr127191-1.c
@@ -1,0 +1,30 @@
+/* { dg-do run } */
+/* { dg-options "-O2" } */
+
+/* Verifies that the potential CC clobber is taken into account when expanding
+   doloop_end but this fails to resolve into a hardware loop.  */
+
+int d = 1, e, f, o, w = 1, q, t;
+
+int
+main (void)
+{
+  int g = 0;
+
+  for (; d; d--)
+    {
+      while (o)
+	while (e)
+	  ;
+
+      g = t ? g : w;
+      f = g;
+      if (g)
+	q = 1;
+    }
+
+  if (q != 1)
+    __builtin_abort ();
+
+  return 0;
+}

--- a/gcc/testsuite/gcc.target/arc/pr127191-2.c
+++ b/gcc/testsuite/gcc.target/arc/pr127191-2.c
@@ -1,0 +1,50 @@
+/* { dg-do run } */
+/* { dg-options "-O2" } */
+
+int q, sink;
+
+int __attribute__ ((noipa))
+flag_clobbers_cc (int a, int b, int *p)
+{
+  int s = a | b;
+
+  *p = s;
+  __builtin_arc_flag (0);
+  if (s == 0)
+    q = 1;
+
+  return s;
+}
+
+#if defined (__ARCEM__) || defined (__ARCHS__)
+int r;
+
+int __attribute__ ((noipa))
+kflag_clobbers_cc (int a, int b, int *p)
+{
+  int s = a | b;
+
+  *p = s;
+  __builtin_arc_kflag (0);
+  if (s == 0)
+    r = 1;
+
+  return s;
+}
+#endif
+
+int
+main (void)
+{
+  flag_clobbers_cc (0, 0, &sink);
+  if (q != 1)
+    __builtin_abort ();
+
+#if defined (__ARCEM__) || defined (__ARCHS__)
+  kflag_clobbers_cc (0, 0, &sink);
+  if (r != 1)
+    __builtin_abort ();
+#endif
+
+  return 0;
+}


### PR DESCRIPTION
This is a similar issue as PR120375.

If doloop_end fails to resolve to a hardware loop end it falls back some instructions that clobber CC. This needs to be advertised before the potential split or else RA will not take it into account.

This fixes gcc.c-torture/execute/pr68185.c for ARC60x and ARC700.

gcc/ChangeLog:

	* config/arc/arc.md: (doloop_end) Clobber CC. (loop_end) Clobber CC.

gcc/testsuite/ChangeLog:

	* gcc.target/arc/loop-6.c: New test.