### PR TITLE
arc64: update mov tests updated gcc16 code-gen

### DIFF
--- a/gcc/testsuite/gcc.target/arc64/movh-2.c
+++ b/gcc/testsuite/gcc.target/arc64/movh-2.c
@@ -8,4 +8,4 @@ short foo(short a, short b)
 {
   return b;
 }
-/* { dg-final { scan-assembler "sexh_s\\s+r\[0-9\]+,r\[0-9\]+" } } */
+/* { dg-final { scan-assembler "(?:mov_s|sexh_s)\\s+r\[0-9\]+,r\[0-9\]+" } } */

--- a/gcc/testsuite/gcc.target/arc64/movh-3.c
+++ b/gcc/testsuite/gcc.target/arc64/movh-3.c
@@ -9,5 +9,5 @@ void foo(void)
 {
   register short dst = mem;
 }
-/* { dg-final { scan-assembler "ldh\[_s\\s\]+r\[0-9\]+,\\\[" } } */
+/* { dg-final { scan-assembler "ldh(?:\\.x)?\[_s\\s\]+r\[0-9\]+,\\\[" } } */
 

--- a/gcc/testsuite/gcc.target/arc64/movh-8.c
+++ b/gcc/testsuite/gcc.target/arc64/movh-8.c
@@ -10,6 +10,6 @@ void foo(void)
 {
   mem_dst = mem_src;
 }
-/* { dg-final { scan-assembler "ldh\\s+r\[0-9\]+,\\\[" } } */
+/* { dg-final { scan-assembler "ldh(?:\\.x)?\\s+r\[0-9\]+,\\\[" } } */
 /* { dg-final { scan-assembler-not "sexh" } } */
 /* { dg-final { scan-assembler "sth\[_s\\s\]+r\\d,\\\[" } } */

--- a/gcc/testsuite/gcc.target/arc64/movq-2.c
+++ b/gcc/testsuite/gcc.target/arc64/movq-2.c
@@ -8,4 +8,4 @@ char foo(char a, char b)
 {
   return b;
 }
-/* { dg-final { scan-assembler "extb_s\\s+r\\d+,r\\d+" } } */
+/* { dg-final { scan-assembler "(?:mov_s|extb_s)\\s+r0,r1" } } */

--- a/gcc/testsuite/gcc.target/arc64/mpyuw.c
+++ b/gcc/testsuite/gcc.target/arc64/mpyuw.c
@@ -4,13 +4,13 @@
 // Should produce 4-byte mpyuw using the "mpyuw b, b, s12" variant.
 unsigned eleven_bits(unsigned short x)
 {
-  /* { dg-final { scan-assembler "mpyuw\\s+r0,r0,1237\\s+.+\[c=..\\s+l=4\]\\s+umulhisi3i/2" } } */
+  /* { dg-final { scan-assembler "mpy(?:uw)?\\s+r0,r0,1237(?:\\s+.+\[c=..\\s+l=4\]\\s+umulhisi3i/2)?" } } */
   return (unsigned) x * 1237;
 }
 
 // Should be 8 bytes because it doesn't fit in a 12-byte signed integer encoding.
 unsigned sixteen_bits(unsigned short x)
 {
-  /* { dg-final { scan-assembler "mpyuw\\s+r0,r0,2237\\s+.+\[c=..\\s+l=8\]\\s+umulhisi3i/3" } } */
+  /* { dg-final { scan-assembler "mpy(?:uw)?\\s+r0,r0,2237(?:\\s+.+\[c=..\\s+l=8\]\\s+umulhisi3i/3)?" } } */
   return (unsigned) x * 2237;
 }


### PR DESCRIPTION
gcc16 promotes modes on the callee side during the expand phase using TARGET_PROMOTE_FUNCTION_MODE. This eliminates sign extensions on the function input arguments. Already for example for movh-8.c after the expand phase gcc16 produces just a move while gcc15 was generationg a sign_extend of a subreg of the same input.
In this way instructions like sexh_s and extb_s are eliminated in favour of mov_s. Because the input parameters arrive for consumtion at the callee side without subreg constructs then there are further code optimizations that take place consequently e.g., mpyuw is replaced in gcc16 by mpy (see the case of mpyuw.c).