### PR TITLE
fixup! arc: Fix dmpywh/qmpyh reduction destinations

### DIFF
--- a/gcc/testsuite/gcc.target/arc/arc.exp
+++ b/gcc/testsuite/gcc.target/arc/arc.exp
@@ -60,6 +60,15 @@ proc check_effective_target_arcmpy { } {
     }]
 }
 
+# Return 1 if we have the ARC HS quad multiply option
+proc check_effective_target_qmacw { } {
+    return [check_no_compiler_messages qmacw assembly {
+	#if !defined(__ARC_MPY_QMACW__) || !defined(__ARCHS__)
+	#error No QMACW
+	#endif
+    }]
+}
+
 # Return 1 if this is a compiler supporting ARC HS as default processor
 proc check_effective_target_archs { } {
     return [check_no_compiler_messages archs assembly {

--- a/gcc/testsuite/gcc.target/arc/reduc-plus-scal-1.c
+++ b/gcc/testsuite/gcc.target/arc/reduc-plus-scal-1.c
@@ -1,6 +1,5 @@
 /* { dg-do run } */
-/* { dg-skip-if "" { *-*-* } { "-mcpu=*" } { "-mcpu=hs38_linux" } } */
-/* { dg-options "-O3 -mcpu=hs38_linux -save-temps -fdump-rtl-expand" } */
+/* { dg-options "-O3 -save-temps -fdump-rtl-expand" } */
 
 typedef int v2si __attribute__ ((vector_size (8)));
 
@@ -53,8 +52,8 @@ main (void)
   return 0;
 }
 
-/* { dg-final { scan-rtl-dump "unspec:DI \\\[\\n\[^\\n\]*\\n\[^\\n\]*UNSPEC_ARC_DMPYWH" "expand" } } */
-/* { dg-final { scan-rtl-dump "unspec:DI \\\[\\n\[^\\n\]*\\n\[^\\n\]*UNSPEC_ARC_QMPYH" "expand" } } */
+/* { dg-final { scan-rtl-dump "unspec:DI \\\[\\n\[^\\n\]*\\n\[^\\n\]*UNSPEC_ARC_DMPYWH" "expand" { target qmacw } } } */
+/* { dg-final { scan-rtl-dump "unspec:DI \\\[\\n\[^\\n\]*\\n\[^\\n\]*UNSPEC_ARC_QMPYH" "expand" { target qmacw } } } */
 
 /* register pair must use an even destination.  */
 /* { dg-final { scan-assembler-not "dmpywh\\s+r\[0-9\]*\[13579\]," } } */


### PR DESCRIPTION
fix gcc/testsuite/gcc.target/arc/reduc-plus-scal-1.c
test failed for em
now the run part works for em, and the asm scan is only performed for hs38