### PR TITLE
mips riscv: add support to xmipslsp extension

### DIFF
--- a/gcc/config/riscv/mips-insn.md
+++ b/gcc/config/riscv/mips-insn.md
@@ -34,6 +34,189 @@
 [(set_attr "type" "condmove")
  (set_attr "mode" "<GPR:MODE>")])
 
+(define_mode_iterator JOIN_MODE [HI
+                                  SI
+                                  (DI "TARGET_64BIT")
+                                  (SF "TARGET_HARD_FLOAT")
+                                  (DF "TARGET_DOUBLE_FLOAT")])
+
+;; 2 HI/SI/DI/SF/DF loads are joined.
+;; Daimyo does not support bonding of two LBs, hence QI mode is not included.
+;; The loads must be non-volatile as they might be reordered at the time of asm
+;; generation.
+(define_peephole2
+  [(set (match_operand:JOIN_MODE 0 "register_operand")
+        (match_operand:JOIN_MODE 1 "non_volatile_mem_operand"))
+    (set (match_operand:JOIN_MODE 2 "register_operand")
+        (match_operand:JOIN_MODE 3 "non_volatile_mem_operand"))]
+    "TARGET_XMIPSLSP
+    && riscv_load_store_bonding_p (operands, <JOIN_MODE:MODE>mode, true)"
+    [(parallel [(set (match_dup 0)
+                    (match_dup 1))
+                (set (match_dup 2)
+                    (match_dup 3))])]
+  "")
+
+;; 2 HI/SI/DI/SF/DF stores are joined.
+;; Daimyo does not support bonding of two SBs, hence QI mode is not included.
+(define_peephole2
+  [(set (match_operand:JOIN_MODE 0 "memory_operand")
+        (match_operand:JOIN_MODE 1 "register_operand"))
+    (set (match_operand:JOIN_MODE 2 "memory_operand")
+        (match_operand:JOIN_MODE 3 "register_operand"))]
+    "TARGET_XMIPSLSP
+    && riscv_load_store_bonding_p (operands, <JOIN_MODE:MODE>mode, false)"
+  [(parallel [(set (match_dup 0)
+                   (match_dup 1))
+              (set (match_dup 2)
+                   (match_dup 3))])]
+  "")
+
+;; 2 HI loads are joined.
+(define_peephole2
+  [(set (match_operand:SI 0 "register_operand")
+        (any_extend:SI (match_operand:HI 1 "non_volatile_mem_operand")))
+   (set (match_operand:SI 2 "register_operand")
+        (any_extend:SI (match_operand:HI 3 "non_volatile_mem_operand")))]
+  "TARGET_XMIPSLSP
+   && riscv_load_store_bonding_p (operands, HImode, true)"
+  [(parallel [(set (match_dup 0)
+                   (any_extend:SI (match_dup 1)))
+              (set (match_dup 2)
+                   (any_extend:SI (match_dup 3)))])]
+  "")
+
+;; 2 HI loads are joined.
+(define_peephole2
+  [(set (match_operand:DI 0 "register_operand")
+        (any_extend:DI (match_operand:HI 1 "non_volatile_mem_operand")))
+   (set (match_operand:DI 2 "register_operand")
+        (any_extend:DI (match_operand:HI 3 "non_volatile_mem_operand")))]
+  "TARGET_XMIPSLSP && TARGET_64BIT
+   && riscv_load_store_bonding_p (operands, HImode, true)"
+  [(parallel [(set (match_dup 0)
+                   (any_extend:DI (match_dup 1)))
+              (set (match_dup 2)
+                   (any_extend:DI (match_dup 3)))])]
+  "")
+
+;; 2 SI loads are joined.
+(define_peephole2
+  [(set (match_operand:DI 0 "register_operand")
+        (any_extend:DI (match_operand:SI 1 "non_volatile_mem_operand")))
+   (set (match_operand:DI 2 "register_operand")
+        (any_extend:DI (match_operand:SI 3 "non_volatile_mem_operand")))]
+  "TARGET_XMIPSLSP && TARGET_64BIT
+   && riscv_load_store_bonding_p (operands, SImode, true)"
+  [(parallel [(set (match_dup 0)
+                   (any_extend:DI (match_dup 1)))
+              (set (match_dup 2)
+                   (any_extend:DI (match_dup 3)))])]
+  "")
+
+;; Match paired HI/SI/DI/SF/DFmode load/stores.
+(define_insn "*join2_load_store<JOIN_MODE:mode>"
+  [(set (match_operand:JOIN_MODE 0 "nonimmediate_operand" "=r,f,m,m")
+        (match_operand:JOIN_MODE 1 "nonimmediate_operand" "m,m,r,f"))
+   (set (match_operand:JOIN_MODE 2 "nonimmediate_operand" "=r,f,m,m")
+        (match_operand:JOIN_MODE 3 "nonimmediate_operand" "m,m,r,f"))]
+  "TARGET_XMIPSLSP && reload_completed"
+  {
+    bool load_p = (which_alternative == 0 || which_alternative == 1);
+    return riscv_output_join2_insns (operands, <JOIN_MODE:MODE>mode, load_p,
+                                     false);
+  }
+  [(set_attr "move_type" "load,fpload,store,fpstore")
+   (set_attr "mode" "<JOIN_MODE:MODE>")])
+
+;; Match paired HImode loads.
+(define_insn "*join2_loadsihi"
+  [(set (match_operand:SI 0 "register_operand" "=r")
+        (any_extend:SI (match_operand:HI 1 "non_volatile_mem_operand" "m")))
+   (set (match_operand:SI 2 "register_operand" "=r")
+        (any_extend:SI (match_operand:HI 3 "non_volatile_mem_operand" "m")))]
+  "TARGET_XMIPSLSP && reload_completed"
+  {
+    if (!reg_overlap_mentioned_p (operands[0], operands[3]))
+    {
+      output_asm_insn ("lh<u>\t%0,%1", operands);
+      output_asm_insn ("lh<u>\t%2,%3", operands);
+    }
+    else
+    {
+      /* Make sure operands[2] and operands[1] don't overlap.  */
+      gcc_assert (!reg_overlap_mentioned_p (operands[2], operands[1]));
+      output_asm_insn ("lh<u>\t%2,%3", operands);
+      output_asm_insn ("lh<u>\t%0,%1", operands);
+    }
+    return "";
+  }
+  [(set_attr "move_type" "load")
+   (set_attr "mode" "HI")])
+
+;; Match paired HImode loads.
+(define_insn "*join2_loaddihi"
+  [(set (match_operand:DI 0 "register_operand" "=r")
+        (any_extend:DI (match_operand:HI 1 "non_volatile_mem_operand" "m")))
+   (set (match_operand:DI 2 "register_operand" "=r")
+        (any_extend:DI (match_operand:HI 3 "non_volatile_mem_operand" "m")))]
+  "TARGET_XMIPSLSP && TARGET_64BIT && reload_completed"
+  {
+    if (!reg_overlap_mentioned_p (operands[0], operands[3]))
+    {
+      output_asm_insn ("lh<u>\t%0,%1", operands);
+      output_asm_insn ("lh<u>\t%2,%3", operands);
+    }
+    else
+    {
+      /* Make sure operands[2] and operands[1] don't overlap.  */
+      gcc_assert (!reg_overlap_mentioned_p (operands[2], operands[1]));
+      output_asm_insn ("lh<u>\t%2,%3", operands);
+      output_asm_insn ("lh<u>\t%0,%1", operands);
+    }
+    return "";
+  }
+  [(set_attr "move_type" "load")
+   (set_attr "mode" "HI")])
+
+;; Match paired SImode loads.
+(define_insn "*join2_loaddisi_zero_extend"
+  [(set (match_operand:DI 0 "register_operand" "=r")
+        (zero_extend:DI (match_operand:SI 1 "non_volatile_mem_operand" "m")))
+   (set (match_operand:DI 2 "register_operand" "=r")
+        (zero_extend:DI (match_operand:SI 3 "non_volatile_mem_operand" "m")))]
+  "TARGET_XMIPSLSP && TARGET_64BIT && reload_completed"
+  {
+    if (!reg_overlap_mentioned_p (operands[0], operands[3]))
+    {
+      output_asm_insn ("lwu\t%0,%1", operands);
+      output_asm_insn ("lwu\t%2,%3", operands);
+    }
+    else
+    {
+      /* Make sure operands[2] and operands[1] don't overlap.  */
+      gcc_assert (!reg_overlap_mentioned_p (operands[2], operands[1]));
+      output_asm_insn ("lwu\t%2,%3", operands);
+      output_asm_insn ("lwu\t%0,%1", operands);
+    }
+    return "";
+  }
+  [(set_attr "move_type" "load")
+   (set_attr "mode" "SI")])
+
+;; Match paired SImode loads.
+(define_insn "*join2_loaddisi_sign_extend"
+  [(set (match_operand:DI 0 "register_operand" "=r")
+        (sign_extend:DI (match_operand:SI 1 "non_volatile_mem_operand" "m")))
+   (set (match_operand:DI 2 "register_operand" "=r")
+        (sign_extend:DI (match_operand:SI 3 "non_volatile_mem_operand" "m")))]
+  "TARGET_XMIPSLSP && TARGET_64BIT && reload_completed"
+  {
+    return riscv_output_join2_insns (operands, SImode, true, true);
+  }
+  [(set_attr "move_type" "load")
+   (set_attr "mode" "SI")])
+
 ;; flti instruction
 (define_insn "riscv_mips_flti"
   [(set (match_operand:SF 0 "register_operand" "=f")

--- a/gcc/config/riscv/predicates.md
+++ b/gcc/config/riscv/predicates.md
@@ -744,6 +744,11 @@
          && type == SYMBOL_PCREL);
 })
 
+;; Return 1 if the operand is in non-volatile memory.
+(define_predicate "non_volatile_mem_operand"
+  (and (match_operand 0 "memory_operand")
+       (not (match_test "MEM_VOLATILE_P (op)"))))
+
 ;; Shadow stack operands only allow x1, x5 registers
 (define_predicate "x1x5_operand"
   (and (match_operand 0 "register_operand")

--- a/gcc/config/riscv/riscv-ext-mips.def
+++ b/gcc/config/riscv/riscv-ext-mips.def
@@ -59,3 +59,16 @@ DEFINE_RISCV_EXT (
   /* BITMASK_GROUP_ID.  */ BITMASK_NOT_YET_ALLOCATED,
   /* BITMASK_BIT_POSITION.  */ BITMASK_NOT_YET_ALLOCATED,
   /* EXTRA_EXTENSION_FLAGS.  */ 0)
+
+DEFINE_RISCV_EXT (
+  /* NAME.  */ xmipslsp,
+  /* UPPERCASE_NAME.  */ XMIPSLSP,
+  /* FULL_NAME.  */ "Mips load/store pairs extension",
+  /* DESC.  */ "",
+  /* URL.  */ ,
+  /* DEP_EXTS.  */ ({}),
+  /* SUPPORTED_VERSIONS.  */ ({{1, 0}}),
+  /* FLAG_GROUP.  */ xmips,
+  /* BITMASK_GROUP_ID.  */ BITMASK_NOT_YET_ALLOCATED,
+  /* BITMASK_BIT_POSITION.  */ BITMASK_NOT_YET_ALLOCATED,
+  /* EXTRA_EXTENSION_FLAGS.  */ 0)

--- a/gcc/config/riscv/riscv-ext.opt
+++ b/gcc/config/riscv/riscv-ext.opt
@@ -467,6 +467,8 @@ Mask(XMIPSCBOP) Var(riscv_xmips_subext)
 
 Mask(XMIPSTRIG) Var(riscv_xmips_subext)
 
+Mask(XMIPSLSP) Var(riscv_xmips_subext)
+
 Mask(XANDESPERF) Var(riscv_xandes_subext)
 
 Mask(XANDESBFHCVT) Var(riscv_xandes_subext)

--- a/gcc/config/riscv/riscv-protos.h
+++ b/gcc/config/riscv/riscv-protos.h
@@ -927,4 +927,7 @@ enum
   RISCV_REVISION_VERSION_BASE = 1,
 };
 
+extern bool riscv_load_store_bonding_p (rtx *, machine_mode, bool);
+extern const char *riscv_output_join2_insns (rtx *, machine_mode, bool, bool);
+
 #endif /* ! GCC_RISCV_PROTOS_H */

--- a/gcc/config/riscv/riscv.cc
+++ b/gcc/config/riscv/riscv.cc
@@ -13669,6 +13669,181 @@ riscv_gpr_save_operation_p (rtx op)
   return true;
 }
 
+/* If X is a PLUS of a CONST_INT, return the two terms in *BASE_PTR
+   and *OFFSET_PTR.  Return X in *BASE_PTR and 0 in *OFFSET_PTR otherwise.  */
+
+static void
+riscv_split_plus (rtx x, rtx *base_ptr, HOST_WIDE_INT *offset_ptr)
+{
+  if (GET_CODE (x) == PLUS && CONST_INT_P (XEXP (x, 1)))
+    {
+      *base_ptr = XEXP (x, 0);
+      *offset_ptr = INTVAL (XEXP (x, 1));
+    }
+  else
+    {
+      *base_ptr = x;
+      *offset_ptr = 0;
+    }
+}
+
+bool
+riscv_load_store_bonding_p (rtx *operands, machine_mode mode, bool load_p)
+{
+  rtx reg1, reg2, mem1, mem2, base1, base2;
+  enum reg_class rc1, rc2;
+  HOST_WIDE_INT offset1, offset2, mode_size;
+
+  if (load_p)
+    {
+      reg1 = operands[0];
+      reg2 = operands[2];
+      mem1 = operands[1];
+      mem2 = operands[3];
+    }
+  else
+    {
+      reg1 = operands[1];
+      reg2 = operands[3];
+      mem1 = operands[0];
+      mem2 = operands[2];
+    }
+
+  if (riscv_address_insns (XEXP (mem1, 0), mode, false) == 0
+      || riscv_address_insns (XEXP (mem2, 0), mode, false) == 0)
+    return false;
+
+  riscv_split_plus (XEXP (mem1, 0), &base1, &offset1);
+  riscv_split_plus (XEXP (mem2, 0), &base2, &offset2);
+
+  /* Base regs do not match.  */
+  if (!REG_P (base1) || !rtx_equal_p (base1, base2))
+    return false;
+
+  /* Either of the loads is clobbering base register.  It is legitimate to bond
+     loads if second load clobbers base register.  However, hardware does not
+     support such bonding.  */
+  if (load_p
+      && (REGNO (reg1) == REGNO (base1)
+	  || (REGNO (reg2) == REGNO (base1))))
+    return false;
+
+  /* Loading in same registers.  */
+  if (load_p
+      && REGNO (reg1) == REGNO (reg2))
+    return false;
+
+  /* The loads/stores are not of same type.  */
+  rc1 = REGNO_REG_CLASS (REGNO (reg1));
+  rc2 = REGNO_REG_CLASS (REGNO (reg2));
+  if (rc1 != rc2
+      && !reg_class_subset_p (rc1, rc2)
+      && !reg_class_subset_p (rc2, rc1))
+    return false;
+
+  /* Make sure offset1 is aligned to the mode size.  */
+  mode_size = GET_MODE_SIZE (mode).to_constant();
+  if ((offset1 & (mode_size - 1)) != 0)
+    return false;
+
+  if (abs (offset1 - offset2) != mode_size)
+    return false;
+
+  return true;
+}
+
+const char *
+riscv_output_join2_insns (rtx *operands, machine_mode mode, bool load_p,
+			  bool sign_extend_p)
+{
+  rtx reg1, reg2, mem1, mem2, base1, base2;
+  HOST_WIDE_INT offset1, offset2;
+
+  if (load_p)
+    {
+      reg1 = operands[0];
+      reg2 = operands[2];
+      mem1 = operands[1];
+      mem2 = operands[3];
+    }
+  else
+    {
+      reg1 = operands[1];
+      reg2 = operands[3];
+      mem1 = operands[0];
+      mem2 = operands[2];
+    }
+
+  gcc_assert (riscv_address_insns (XEXP (mem1, 0), mode, false));
+  gcc_assert (riscv_address_insns (XEXP (mem2, 0), mode, false));
+
+  riscv_split_plus (XEXP (mem1, 0), &base1, &offset1);
+  riscv_split_plus (XEXP (mem2, 0), &base2, &offset2);
+
+  /* Check if we want to output ldp/sdp/lwp/swp.  */
+  if (TARGET_XMIPSLSP
+      && abs (offset1 - offset2) == GET_MODE_SIZE (mode).to_constant()
+      && offset1 >= 0 && offset2 >= 0
+      && (offset1 < (1 << 7) || offset2 < (1 << 7))
+      && (mode == DImode || mode == SImode)
+      && REGNO (base1) == REGNO (base2)
+      && ((load_p && REGNO (reg1) != REGNO (base1)
+	   && REGNO (reg2) != REGNO (base1)) || !load_p))
+  {
+    if (offset1 < offset2)
+    {
+      if (load_p)
+	return mode == DImode ? "mips.ldp\t%0,%2,%1" : "mips.lwp\t%0,%2,%1";
+      else
+	return mode == DImode ? "mips.sdp\t%z1,%z3,%0" : "mips.swp\t%z1,%z3,%0";
+    }
+    else
+    {
+      if (load_p)
+	return mode == DImode ? "mips.ldp\t%2,%0,%3" : "mips.lwp\t%2,%0,%3";
+      else
+	return mode == DImode ? "mips.sdp\t%z3,%z1,%2" : "mips.swp\t%z3,%z1,%2";
+    }
+  }
+
+  if (!load_p || !reg_overlap_mentioned_p (operands[0], operands[3]))
+    {
+    /* Special treatment to use lw.  */
+    if (sign_extend_p && mode == SImode) {
+      output_asm_insn ("lw\t%0,%1", operands);
+      output_asm_insn ("lw\t%2,%3", operands);
+
+    }
+    else
+    {
+      output_asm_insn (riscv_output_move (operands[0], operands[1]),
+					  operands);
+      output_asm_insn (riscv_output_move (operands[2], operands[3]),
+					  &operands[2]);
+    }
+  }
+  else
+  {
+    /* Make sure operands[2] and operands[1] don't overlap.  */
+    gcc_assert(!reg_overlap_mentioned_p (operands[2], operands[1]));
+
+    /* Special treatment to use lw.  */
+    if (sign_extend_p && mode == SImode)
+    {
+      output_asm_insn ("lw\t%2,%3", operands);
+      output_asm_insn ("lw\t%0,%1", operands);
+    }
+    else
+    {
+      output_asm_insn (riscv_output_move (operands[2], operands[3]),
+					  &operands[2]);
+      output_asm_insn (riscv_output_move (operands[0], operands[1]), operands);
+    }
+  }
+
+  return "";
+}
+
 /* Implement TARGET_ASAN_SHADOW_OFFSET.  */
 
 static unsigned HOST_WIDE_INT

--- a/gcc/doc/riscv-ext.texi
+++ b/gcc/doc/riscv-ext.texi
@@ -734,6 +734,10 @@
 @tab 1.0
 @tab Mips trigonometryextension
 
+@item @samp{xmipslsp}
+@tab 1.0
+@tab Mips load/store pairs extension
+
 @item @samp{xandesperf}
 @tab 5.0
 @tab Andes performace extension

--- a/gcc/testsuite/gcc.target/riscv/xmipspairs.c
+++ b/gcc/testsuite/gcc.target/riscv/xmipspairs.c
@@ -1,0 +1,26 @@
+/* { dg-do compile } */
+/* { dg-options "-march=rv32gc_xmipslsp -mtune=mips-m8500" { target { rv32 } } } */
+/* { dg-skip-if "" { *-*-* } { "-O0" "-O1" "-Os" "-Og" "-Oz" } } */
+
+#define MYTEST(name, mytype) \
+void test1 ## name (mytype *a, mytype *total) \
+{ \
+  mytype b = *a++; \
+  mytype c = *a; \
+  *total = b + c; \
+} \
+void test2 ## name (mytype *s, mytype a, mytype b) \
+{ \
+  *s++ = a; \
+  *s = b; \
+}
+
+MYTEST(1, long long)
+MYTEST(2, unsigned long long)
+MYTEST(3, long)
+MYTEST(4, unsigned long)
+MYTEST(5, int)
+MYTEST(6, unsigned long)
+
+/* { dg-final { scan-assembler-times "mips.lwp" 6 } } */
+/* { dg-final { scan-assembler-times "mips.swp" 10 } } */


### PR DESCRIPTION
new instruction supported:
mips.lwp, mips.swp, mips.ldp and mips.sdp